### PR TITLE
Add TLS support for connecting to arangodb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ adbnx_adapter/dist/
 # Remove the build directory from repo
 adbnx_adapter/build/
 adbnx_adapter/*.egg-info
+*.swp
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ con = {'dbName': 'YOURDBNAME',
  'username': 'YOURUSERNAME',
  'password': 'YOURPASSOWRD',
  'hostname': 'instance.arangodb.cloud',
- 'port': 8529}
+ 'port': 8529,
+ 'crt': '/path/to/crt'}
 
 # Create Adapter instance
 ma = ArangoDB_Networkx_Adapter(conn = con)


### PR DESCRIPTION
1. Support connecting ArangoDB via TLS;
2. Update the example in Readme.