### PR TITLE
set dgl version in notebook

### DIFF
--- a/examples/ITSM_ArangoDB_Adapter.ipynb
+++ b/examples/ITSM_ArangoDB_Adapter.ipynb
@@ -52,7 +52,7 @@
     "!pip3 install matplotlib\n",
     "!pip3 install pyarango\n",
     "!pip3 install python-arango\n",
-    "!pip install dgl"
+    "!pip install dgl==0.4.3.post2"
    ]
   },
   {


### PR DESCRIPTION
The `ITSM_ArangoDB_Adapter` notebook requires `dgl` set to `0.4.3.post2`.