### PR TITLE
disable twine skip-existing flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,11 +116,11 @@ jobs:
         run: cat version_changelog.md
 
       - name: TestPypi release
-        run: twine upload --repository testpypi dist/* -p ${{ secrets.TWINE_PASSWORD_TEST }} --skip-existing
+        run: twine upload --repository testpypi dist/* -p ${{ secrets.TWINE_PASSWORD_TEST }} #--skip-existing
         working-directory: ${{env.SOURCE_DIR}}
 
       - name: Pypi release
-        run: twine upload dist/* -p ${{ secrets.TWINE_PASSWORD }} --skip-existing
+        run: twine upload dist/* -p ${{ secrets.TWINE_PASSWORD }} #--skip-existing
         working-directory: ${{env.SOURCE_DIR}}
 
       - name: Github release


### PR DESCRIPTION
This flag was only enable to fix the release issues we experienced at the start (#40, #41).

From this point on, there should be no reason to keep this flag enabled, but we will keep it as a comment just in case something goes wrong in the future.