### PR TITLE
new: adjust NetworkX to ArangoDB interface for increased accessibility

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -52,7 +52,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -66,4 +66,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run mypy
         run: mypy ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
       - name: Run pytest
-        run: py.test --cov=${{env.PACKAGE_DIR}} --cov-report xml --cov-report term-missing -v --color=yes --no-cov-on-fail --code-highlight=yes
+        run: py.test -s --cov=${{env.PACKAGE_DIR}} --cov-report xml --cov-report term-missing -v --color=yes --no-cov-on-fail --code-highlight=yes
       - name: Publish to coveralls.io
         if: matrix.python == '3.8'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10"]
     name: Python ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10"]
     name: Python ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <a href="https://www.arangodb.com/" rel="arangodb.com">![](./examples/assets/logos/ArangoDB_logo.png)</a>
 <a href="https://networkx.org/" rel="networkx.org">![](./examples/assets/logos/networkx_logo.svg)</a>
 
-The ArangoDB-Networkx Adapter exports Graphs from ArangoDB, a multi-model Graph Database, into NetworkX, the swiss army knife for graph analysis with python, and vice-versa.
+The ArangoDB-Networkx Adapter exports Graphs from ArangoDB, the multi-model Graph Database, into NetworkX, the swiss army knife for graph analysis with python, and vice-versa.
 
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <a href="https://www.arangodb.com/" rel="arangodb.com">![](./examples/assets/logos/ArangoDB_logo.png)</a>
 <a href="https://networkx.org/" rel="networkx.org">![](./examples/assets/logos/networkx_logo.svg)</a>
 
-The ArangoDB-Networkx Adapter exports Graphs from ArangoDB, the multi-model Graph Database, into NetworkX, the swiss army knife for graph analysis with python, and vice-versa.
+The ArangoDB-Networkx Adapter exports Graphs from ArangoDB, the multi-model database for graph & beyond, into NetworkX, the swiss army knife for graph analysis with python, and vice-versa.
 
 
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ from networkx import grid_2d_graph
 
 # Instantiate driver client based on user preference
 # Let's assume that the ArangoDB "fraud detection" dataset is imported to this endpoint for example purposes
-db = ArangoClient(hosts="http://localhost:8529").db("_system", username="root", password="openSesame")
+db = ArangoClient(hosts="http://localhost:8529").db("_system", username="root", password="")
 
 # Instantiate your ADBNX Adapter with driver client
 adbnx_adapter = ADBNX_Adapter(db)

--- a/adbnx_adapter/abc.py
+++ b/adbnx_adapter/abc.py
@@ -49,22 +49,11 @@ class Abstract_ADBNX_Adapter(ABC):
     ) -> ADBGraph:
         raise NotImplementedError  # pragma: no cover
 
-    def __validate_attributes(self) -> None:
-        raise NotImplementedError  # pragma: no cover
-
     def __fetch_adb_docs(self) -> None:
         raise NotImplementedError  # pragma: no cover
 
     def __insert_adb_docs(self) -> None:
         raise NotImplementedError  # pragma: no cover
-
-    @property
-    def METAGRAPH_ATRIBS(self) -> Set[str]:
-        return {"vertexCollections", "edgeCollections"}
-
-    @property
-    def EDGE_DEFINITION_ATRIBS(self) -> Set[str]:
-        return {"edge_collection", "from_vertex_collections", "to_vertex_collections"}
 
 
 class Abstract_ADBNX_Controller(ABC):

--- a/adbnx_adapter/abc.py
+++ b/adbnx_adapter/abc.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from abc import ABC
-from typing import Any, List, Set
+from typing import Any, List, Optional, Set
 
 from arango.graph import Graph as ADBGraph
 from networkx.classes.graph import Graph as NXGraph
@@ -42,17 +42,15 @@ class Abstract_ADBNX_Adapter(ABC):
         self,
         name: str,
         nx_graph: NXGraph,
-        edge_definitions: List[Json],
-        batch_size: int = 1000,
+        edge_definitions: Optional[List[Json]] = None,
         keyify_nodes: bool = False,
         keyify_edges: bool = False,
+        overwrite_graph: bool = False,
+        **import_options: Any,
     ) -> ADBGraph:
         raise NotImplementedError  # pragma: no cover
 
     def __fetch_adb_docs(self) -> None:
-        raise NotImplementedError  # pragma: no cover
-
-    def __insert_adb_docs(self) -> None:
         raise NotImplementedError  # pragma: no cover
 
 

--- a/adbnx_adapter/adapter.py
+++ b/adbnx_adapter/adapter.py
@@ -107,7 +107,6 @@ class ADBNX_Adapter(Abstract_ADBNX_Adapter):
         }
         """
         logger.debug(f"Starting arangodb_to_networkx({name}, ...):")
-        self.__validate_attributes("graph", set(metagraph), self.METAGRAPH_ATRIBS)
 
         # Maps ArangoDB vertex IDs to NetworkX node IDs
         adb_map: Dict[str, Dict[str, NxId]] = dict()
@@ -258,11 +257,6 @@ class ADBNX_Adapter(Abstract_ADBNX_Adapter):
         if edge_definitions is None:
             logger.debug(f"Assuming {name} already exists. Grabbing edge_definitions.")
             edge_definitions = self.__db.graph(name).edge_definitions()
-        else:
-            for e_d in edge_definitions:
-                self.__validate_attributes(
-                    "Edge Definitions", set(e_d), self.EDGE_DEFINITION_ATRIBS
-                )
 
         if overwrite:
             logger.debug("Overwrite is True. Deleting existing graph & collections.")
@@ -353,25 +347,6 @@ class ADBNX_Adapter(Abstract_ADBNX_Adapter):
 
         logger.info(f"Created ArangoDB '{name}' Graph")
         return adb_graph
-
-    def __validate_attributes(
-        self, type: str, attributes: Set[str], valid_attributes: Set[str]
-    ) -> None:
-        """Validates that a set of attributes includes the required valid
-        attributes.
-
-        :param type: The context of the attribute validation
-            (e.g connection attributes, graph attributes, etc).
-        :type type: str
-        :param attributes: The provided attributes, possibly invalid.
-        :type attributes: Set[str]
-        :param valid_attributes: The valid attributes.
-        :type valid_attributes: Set[str]
-        :raise ValueError: If **valid_attributes** is not a subset of **attributes**
-        """
-        if valid_attributes.issubset(attributes) is False:
-            missing_attributes = valid_attributes - attributes
-            raise ValueError(f"Missing {type} attributes: {missing_attributes}")
 
     def __fetch_adb_docs(
         self, col: str, attributes: Set[str], is_keep: bool, query_options: Any

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,5 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "setuptools_scm[toml]>=3.4",
-    "wheel",
-]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license="Apache Software License",
     install_requires=[
         "requests>=2.27.1",
-        "python-arango>=7.3.1",
+        "python-arango>=7.4.0",
         "networkx>=2.5.1",
         "setuptools>=45",
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,15 +14,13 @@ setup(
     keywords=["arangodb", "networkx", "adapter"],
     packages=["adbnx_adapter"],
     include_package_data=True,
-    use_scm_version=True,
     python_requires=">=3.6",
     license="Apache Software License",
     install_requires=[
         "requests>=2.27.1",
         "python-arango>=7.3.1",
         "networkx>=2.5.1",
-        "setuptools>=42",
-        "setuptools_scm[toml]>=3.4",
+        "setuptools>=45",
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,8 +102,8 @@ def arango_restore(con: Json, path_to_data: str) -> None:
     )
 
 
-def get_grid_graph() -> NXGraph:
-    return grid_2d_graph(5, 5)
+def get_grid_graph(n: int) -> NXGraph:
+    return grid_2d_graph(n, n)
 
 
 def get_football_graph() -> NXGraph:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,13 +117,6 @@ def get_football_graph() -> NXGraph:
     return nx.parse_gml(gml_list)
 
 
-def get_letter_graph() -> NXGraph:
-    nx_g = nx.Graph()
-    nx_g.add_nodes_from(["A/1", "B/1", "F/1"])
-    nx_g.add_edge("A/1", "B/1")
-    return nx_g
-
-
 class IMDB_ADBNX_Controller(ADBNX_Controller):
     def _prepare_arangodb_vertex(self, adb_vertex: Json, col: str) -> None:
         adb_vertex["bipartite"] = 0 if col == "Users" else 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,9 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
+import networkx as nx
 from arango import ArangoClient
 from arango.database import StandardDatabase
-from networkx import grid_2d_graph, parse_gml
 from networkx.classes import Graph as NXGraph
 
 from adbnx_adapter import ADBNX_Adapter, ADBNX_Controller
@@ -103,7 +103,7 @@ def arango_restore(con: Json, path_to_data: str) -> None:
 
 
 def get_grid_graph(n: int) -> NXGraph:
-    return grid_2d_graph(n, n)
+    return nx.grid_2d_graph(n, n)
 
 
 def get_football_graph() -> NXGraph:
@@ -114,7 +114,14 @@ def get_football_graph() -> NXGraph:
     zf = zipfile.ZipFile(s)
     gml = zf.read("football.gml").decode()
     gml_list = gml.split("\n")[1:]
-    return parse_gml(gml_list)
+    return nx.parse_gml(gml_list)
+
+
+def get_letter_graph() -> NXGraph:
+    nx_g = nx.Graph()
+    nx_g.add_nodes_from(["A/1", "B/1", "F/1"])
+    nx_g.add_edge("A/1", "B/1")
+    return nx_g
 
 
 class IMDB_ADBNX_Controller(ADBNX_Controller):

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -19,12 +19,6 @@ from .conftest import (
 )
 
 
-def test_validate_attributes() -> None:
-    with pytest.raises(ValueError):
-        bad_metagraph: Dict[str, Any] = dict()
-        adbnx_adapter.arangodb_to_networkx("graph_name", bad_metagraph)
-
-
 def test_validate_constructor() -> None:
     bad_db: Dict[str, Any] = dict()
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -142,12 +142,13 @@ def test_adb_graph_to_nx(
 
 
 @pytest.mark.parametrize(
-    "adapter, name, nx_g, edge_definitions, batch_size, keyify_nodes",
+    "adapter, name, nx_g, edge_definitions, \
+        batch_size, keyify_nodes, keyify_edges, overwrite",
     [
         (
             adbnx_adapter,
             "Grid_v1",
-            get_grid_graph(),
+            get_grid_graph(5),
             [
                 {
                     "edge_collection": "to_v1",
@@ -157,11 +158,14 @@ def test_adb_graph_to_nx(
             ],
             5,
             False,
+            False,
+            False,
         ),
+        (adbnx_adapter, "Grid_v1", get_grid_graph(25), None, 1000, False, False, True),
         (
             grid_adbnx_adapter,
             "Grid_v2",
-            get_grid_graph(),
+            get_grid_graph(5),
             [
                 {
                     "edge_collection": "to_v2",
@@ -170,6 +174,8 @@ def test_adb_graph_to_nx(
                 }
             ],
             1000,
+            True,
+            False,
             True,
         ),
         (
@@ -185,6 +191,8 @@ def test_adb_graph_to_nx(
             ],
             1000,
             True,
+            False,
+            True,
         ),
     ],
 )
@@ -195,9 +203,11 @@ def test_nx_to_adb(
     edge_definitions: List[Json],
     batch_size: int,
     keyify_nodes: bool,
+    keyify_edges: bool,
+    overwrite: bool,
 ) -> None:
     adb_g = adapter.networkx_to_arangodb(
-        name, nx_g, edge_definitions, batch_size, keyify_nodes
+        name, nx_g, edge_definitions, batch_size, keyify_nodes, keyify_edges, overwrite
     )
     assert_arangodb_data(adapter, nx_g, adb_g, keyify_nodes)
 
@@ -312,7 +322,7 @@ def test_full_cycle_from_networkx() -> None:
     if db.has_graph(name):
         db.delete_graph(name, drop_collections=True)
 
-    original_grid_nx_g = get_grid_graph()
+    original_grid_nx_g = get_grid_graph(5)
     grid_edge_definitions = [
         {
             "edge_collection": "to_v3",

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -204,7 +204,7 @@ def test_adb_graph_to_nx(
         ),
         (
             adbnx_adapter,
-            "Sample",
+            "Letter",
             get_letter_graph(),
             [
                 {

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -403,9 +403,8 @@ def assert_arangodb_data(
 ) -> None:
     nx_map = dict()
 
-    edge_definitions = adb_g.edge_definitions()
     adb_v_cols = adb_g.vertex_collections()
-    adb_e_cols = [e_d["edge_collection"] for e_d in edge_definitions]
+    adb_e_cols = [e_d["edge_collection"] for e_d in adb_g.edge_definitions()]
 
     has_one_vcol = len(adb_v_cols) == 1
     has_one_ecol = len(adb_e_cols) == 1


### PR DESCRIPTION
* Closes #80 
* Minor housekeeping
* Drop "official" 3.6 support

## Demo

### ArangoDB to NetworkX use cases
```py

nx_graph = grid_2d_graph(5, 5)
edge_definitions = [
    {
        "edge_collection": "to",
        "from_vertex_collections": ["Grid_Node"],
        "to_vertex_collections": ["Grid_Node"],
    }
]

# Use Case 1: Let ADBNX_Adapter handle the graph creation
adbnx_adapter.networkx_to_arangodb("Grid", nx_graph, edge_definitions)


# Use Case 2: Create the graph prior to ArangoDB to NetworkX call
db.create_graph("Grid", edge_definitions, smart = True, disjoint = True, ...)
adbnx_adapter.networkx_to_arangodb("Grid", nx_graph) # No need to specify the edge definitions in this use case

# Use Case 3: Overwrite the graph due to edge definition modifications
new_edge_definitions = [
    {
        "edge_collection": "to",
        "from_vertex_collections": ["Grid_Node_v2"],
        "to_vertex_collections": ["Grid_Node_v2"],
    }
]
adbnx_adapter.networkx_to_arangodb("Grid", nx_graph, new_edge_definitions, overwrite_graph=True)
```

### Keyword arguments for import_bulk

Users can now specify parameters for the [`import_bulk()` API of python-arango](https://docs.python-arango.com/en/main/specs.html#arango.collection.StandardCollection.import_bulk) via kwargs

```py
adbnx_adapter.networkx_to_arangodb("Grid", nx_graph, edge_definitions, sync=True, on_duplicate="replace", batch_size=50)
```