### PR TITLE
new: more adapter housekeeping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run mypy
         run: mypy ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
       - name: Run pytest
-        run: py.test -s --cov=${{env.PACKAGE_DIR}} --cov-report xml --cov-report term-missing -v --color=yes --no-cov-on-fail --code-highlight=yes
+        run: pytest --cov=${{env.PACKAGE_DIR}} --cov-report xml --cov-report term-missing -v --color=yes --no-cov-on-fail --code-highlight=yes
       - name: Publish to coveralls.io
         if: matrix.python == '3.8'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run mypy
         run: mypy ${{env.PACKAGE_DIR}} ${{env.TESTS_DIR}}
       - name: Run pytest
-        run: py.test --cov=${{env.PACKAGE_DIR}} --cov-report xml --cov-report term-missing -v --color=yes --no-cov-on-fail --code-highlight=yes
+        run: pytest --cov=${{env.PACKAGE_DIR}} --cov-report xml --cov-report term-missing -v --color=yes --no-cov-on-fail --code-highlight=yes
       - name: Publish to coveralls.io
         if: matrix.python == '3.8'
         env:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 [![Code style: black](https://img.shields.io/static/v1?style=for-the-badge&label=code%20style&message=black&color=black)](https://github.com/psf/black)
 [![Downloads](https://img.shields.io/badge/dynamic/json?style=for-the-badge&color=282661&label=Downloads&query=total_downloads&url=https://api.pepy.tech/api/projects/adbnx-adapter)](https://pepy.tech/project/adbnx-adapter)
 
-<a href="https://www.arangodb.com/" rel="arangodb.com">![](./examples/assets/logos/ArangoDB_logo.png)</a>
-<a href="https://networkx.org/" rel="networkx.org">![](./examples/assets/logos/networkx_logo.svg)</a>
+<a href="https://www.arangodb.com/" rel="arangodb.com">![](https://raw.githubusercontent.com/arangoml/networkx-adapter/master/examples/assets/logos/ArangoDB_logo.png)</a>
+<a href="https://networkx.org/" rel="networkx.org">![](https://raw.githubusercontent.com/arangoml/networkx-adapter/master/examples/assets/logos/networkx_logo.svg)</a>
 
 The ArangoDB-Networkx Adapter exports Graphs from ArangoDB, the multi-model database for graph & beyond, into NetworkX, the swiss army knife for graph analysis with python, and vice-versa.
 

--- a/adbnx_adapter/abc.py
+++ b/adbnx_adapter/abc.py
@@ -53,6 +53,9 @@ class Abstract_ADBNX_Adapter(ABC):
     def __fetch_adb_docs(self) -> None:
         raise NotImplementedError  # pragma: no cover
 
+    def __insert_adb_docs(self) -> None:
+        raise NotImplementedError  # pragma: no cover
+
 
 class Abstract_ADBNX_Controller(ABC):
     def _prepare_arangodb_vertex(self, adb_vertex: Json, col: str) -> None:

--- a/adbnx_adapter/adapter.py
+++ b/adbnx_adapter/adapter.py
@@ -351,8 +351,6 @@ class ADBNX_Adapter(Abstract_ADBNX_Adapter):
             ),
             1,
         ):
-            edge_str = f"({from_node_id}, {to_node_id})"
-
             from_n = nx_map[from_node_id]
             to_n = nx_map[to_node_id]
 
@@ -365,6 +363,7 @@ class ADBNX_Adapter(Abstract_ADBNX_Adapter):
             )
 
             if col not in adb_e_cols:
+                edge_str = f"({from_node_id}, {to_node_id})"
                 msg = f"{edge_str} identified as '{col}', which is not in {adb_e_cols}"
                 raise ValueError(msg)
 

--- a/adbnx_adapter/adapter.py
+++ b/adbnx_adapter/adapter.py
@@ -126,7 +126,7 @@ class ADBNX_Adapter(Abstract_ADBNX_Adapter):
                 self.__fetch_adb_docs(v_col, atribs, is_keep, query_options),
                 total=total,
                 desc=v_col,
-                colour="CYAN",  # should we randomly assign a colour? :P
+                colour="CYAN",
                 disable=logger.level > logging.INFO,
             ):
                 adb_id: str = adb_v["_id"]

--- a/adbnx_adapter/adapter.py
+++ b/adbnx_adapter/adapter.py
@@ -121,9 +121,9 @@ class ADBNX_Adapter(Abstract_ADBNX_Adapter):
             for i, adb_v in enumerate(
                 self.__fetch_adb_docs(col, atribs, is_keep, query_options), 1
             ):
-                logger.debug(f'V{i}: {adb_v["_id"]}')
-
                 adb_id: str = adb_v["_id"]
+                logger.debug(f"V{i}: {adb_id}")
+
                 self.__cntrl._prepare_arangodb_vertex(adb_v, col)
                 nx_id: str = adb_v["_id"]
 

--- a/adbnx_adapter/adapter.py
+++ b/adbnx_adapter/adapter.py
@@ -321,7 +321,7 @@ class ADBNX_Adapter(Abstract_ADBNX_Adapter):
             adb_documents[col].append({**nx_node, "_id": adb_v_id})
 
         self.__insert_adb_docs(adb_documents, import_options)
-        adb_documents.clear()  # memory management
+        adb_documents.clear()  # for memory purposes
 
         from_node_id: NxId
         to_node_id: NxId

--- a/adbnx_adapter/adapter.py
+++ b/adbnx_adapter/adapter.py
@@ -261,8 +261,10 @@ class ADBNX_Adapter(Abstract_ADBNX_Adapter):
         else:
             adb_graph = self.__db.create_graph(name, edge_definitions)
 
-        adb_v_cols = adb_graph.vertex_collections()
-        adb_e_cols = [e_d["edge_collection"] for e_d in adb_graph.edge_definitions()]
+        adb_v_cols: List[str] = adb_graph.vertex_collections()
+        adb_e_cols: List[str] = [
+            e_d["edge_collection"] for e_d in adb_graph.edge_definitions()
+        ]
 
         has_one_vcol = len(adb_v_cols) == 1
         has_one_ecol = len(adb_e_cols) == 1
@@ -280,6 +282,11 @@ class ADBNX_Adapter(Abstract_ADBNX_Adapter):
                 if has_one_vcol
                 else self.__cntrl._identify_networkx_node(nx_id, nx_node, adb_v_cols)
             )
+
+            if col not in adb_v_cols:
+                msg = f"'{nx_id}' identified as '{col}', which is not in {adb_v_cols}"
+                raise ValueError(msg)
+
             key = (
                 self.__cntrl._keyify_networkx_node(nx_id, nx_node, col)
                 if keyify_nodes
@@ -313,6 +320,11 @@ class ADBNX_Adapter(Abstract_ADBNX_Adapter):
                     nx_edge, from_n, to_n, adb_e_cols
                 )
             )
+
+            if col not in adb_e_cols:
+                msg = f"'{nx_edge}' identified as '{col}', which is not in {adb_e_cols}"
+                raise ValueError(msg)
+
             key = (
                 self.__cntrl._keyify_networkx_edge(nx_edge, from_n, to_n, col)
                 if keyify_edges

--- a/adbnx_adapter/controller.py
+++ b/adbnx_adapter/controller.py
@@ -53,7 +53,7 @@ class ADBNX_Controller(Abstract_ADBNX_Controller):
         identify which ArangoDB vertex collection it should belong to.
 
         NOTE: You must override this function if len(**adb_v_cols**) > 1
-        OR **nx_node_id* does NOT comply to ArangoDB standards
+        AND **nx_node_id* does NOT comply to ArangoDB standards
         (i.e "{collection}/{key}").
 
         :param nx_node_id: The NetworkX ID of the node.
@@ -83,7 +83,7 @@ class ADBNX_Controller(Abstract_ADBNX_Controller):
         should belong to.
 
         NOTE #1: You must override this function if len(**adb_e_cols**) > 1
-        OR **nx_edge["_id"]** does NOT comply to ArangoDB standards
+        AND **nx_edge["_id"]** does NOT comply to ArangoDB standards
         (i.e "{collection}/{key}").
 
         NOTE #2: The two nodes associated to the **nx_edge** can be accessed
@@ -127,7 +127,7 @@ class ADBNX_Controller(Abstract_ADBNX_Controller):
         # In this case, we assume that **nx_node_id** is already a valid ArangoDB _id
         # Otherwise, user must override this function
         adb_vertex_id: str = str(nx_node_id)
-        return adb_vertex_id.split("/")[1]
+        return self._string_to_arangodb_key_helper(adb_vertex_id.split("/")[1])
 
     def _keyify_networkx_edge(
         self,
@@ -161,7 +161,7 @@ class ADBNX_Controller(Abstract_ADBNX_Controller):
         # In this case, we assume that nx_edge["_id"] is already a valid ArangoDB _id
         # Otherwise, user must override this function
         adb_edge_id: str = nx_edge["_id"]
-        return adb_edge_id.split("/")[1]
+        return self._string_to_arangodb_key_helper(adb_edge_id.split("/")[1])
 
     def _string_to_arangodb_key_helper(self, string: str) -> str:
         """Given a string, derive a valid ArangoDB _key string.

--- a/adbnx_adapter/controller.py
+++ b/adbnx_adapter/controller.py
@@ -30,7 +30,7 @@ class ADBNX_Controller(Abstract_ADBNX_Controller):
         :param col: The ArangoDB collection the vertex belongs to.
         :type col: str
         """
-        return
+        pass
 
     def _prepare_arangodb_edge(self, adb_edge: Json, col: str) -> None:
         """Prepare an ArangoDB edge before it gets inserted into the NetworkX
@@ -44,7 +44,7 @@ class ADBNX_Controller(Abstract_ADBNX_Controller):
         :param col: The ArangoDB collection the edge belongs to.
         :type col: str
         """
-        return
+        pass
 
     def _identify_networkx_node(
         self, nx_node_id: NxId, nx_node: NxData, adb_v_cols: List[str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ omit = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-s -vv -p"
+addopts = "-s -vv"
 minversion = "6.0"
 testpaths = ["tests"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,8 @@ omit = [
     "setup.py",
 ]
 
-[tool.isort]
-profile = "black"
-
 [tool.pytest.ini_options]
+addopts = "-s -vv -p"
 minversion = "6.0"
 testpaths = ["tests"]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [isort]
-profile = "black"
+profile = black
 
 [flake8]
 max-line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,26 +1,5 @@
-[metadata]
-name = adbnx_adapter
-author = Anthony Mahanna
-author_email = anthony.mahanna@arangodb.com
-description = Convert ArangoDB graphs to NetworkX & vice-versa.
-long_description = file: README.md
-long_description_content_type = text/markdown
-url = https://github.com/arangoml/networkx-adapter
-classifiers =
-    Intended Audience :: Developers
-    License :: OSI Approved :: Apache Software License
-    Operating System :: OS Independent
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Topic :: Utilities
-    Typing :: Typed
-
-[options]
-python_requires = >=3.6
+[isort]
+profile = "black"
 
 [flake8]
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "requests>=2.27.1",
         "python-arango>=7.4.1",
         "networkx>=2.5.1",
+        "tqdm>=4.64.0"
         "setuptools>=45",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "requests>=2.27.1",
         "python-arango>=7.4.1",
         "networkx>=2.5.1",
-        "tqdm>=4.64.0"
+        "tqdm>=4.64.0",
         "setuptools>=45",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     keywords=["arangodb", "networkx", "adapter"],
     packages=["adbnx_adapter"],
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     license="Apache Software License",
     install_requires=[
         "requests>=2.27.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,26 +64,36 @@ def pytest_configure(config: Any) -> None:
         db, Football_ADBNX_Controller(), logging_lvl=logging.DEBUG
     )
 
-    arango_restore(con, "examples/data/fraud_dump")
-    arango_restore(con, "examples/data/imdb_dump")
+    if db.has_graph("fraud-detection") is False:
+        arango_restore(con, "examples/data/fraud_dump")
+        db.create_graph(
+            "fraud-detection",
+            edge_definitions=[
+                {
+                    "edge_collection": "accountHolder",
+                    "from_vertex_collections": ["customer"],
+                    "to_vertex_collections": ["account"],
+                },
+                {
+                    "edge_collection": "transaction",
+                    "from_vertex_collections": ["account"],
+                    "to_vertex_collections": ["account"],
+                },
+            ],
+        )
 
-    # Create Fraud Detection Graph
-    adbnx_adapter.db.delete_graph("fraud-detection", ignore_missing=True)
-    adbnx_adapter.db.create_graph(
-        "fraud-detection",
-        edge_definitions=[
-            {
-                "edge_collection": "accountHolder",
-                "from_vertex_collections": ["customer"],
-                "to_vertex_collections": ["account"],
-            },
-            {
-                "edge_collection": "transaction",
-                "from_vertex_collections": ["account"],
-                "to_vertex_collections": ["account"],
-            },
-        ],
-    )
+    if db.has_graph("imdb") is False:
+        arango_restore(con, "examples/data/imdb_dump")
+        db.create_graph(
+            "imdb",
+            edge_definitions=[
+                {
+                    "edge_collection": "Ratings",
+                    "from_vertex_collections": ["Users"],
+                    "to_vertex_collections": ["Movies"],
+                },
+            ],
+        )
 
 
 def arango_restore(con: Json, path_to_data: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import io
-import logging
 import os
 import subprocess
 import urllib.request as urllib
@@ -53,16 +52,10 @@ def pytest_configure(config: Any) -> None:
     )
 
     global adbnx_adapter, imdb_adbnx_adapter, grid_adbnx_adapter, football_adbnx_adapter
-    adbnx_adapter = ADBNX_Adapter(db, logging_lvl=logging.DEBUG)
-    imdb_adbnx_adapter = ADBNX_Adapter(
-        db, IMDB_ADBNX_Controller(), logging_lvl=logging.DEBUG
-    )
-    grid_adbnx_adapter = ADBNX_Adapter(
-        db, Grid_ADBNX_Controller(), logging_lvl=logging.DEBUG
-    )
-    football_adbnx_adapter = ADBNX_Adapter(
-        db, Football_ADBNX_Controller(), logging_lvl=logging.DEBUG
-    )
+    adbnx_adapter = ADBNX_Adapter(db)
+    imdb_adbnx_adapter = ADBNX_Adapter(db, IMDB_ADBNX_Controller())
+    grid_adbnx_adapter = ADBNX_Adapter(db, Grid_ADBNX_Controller())
+    football_adbnx_adapter = ADBNX_Adapter(db, Football_ADBNX_Controller())
 
     if db.has_graph("fraud-detection") is False:
         arango_restore(con, "examples/data/fraud_dump")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import networkx as nx
 from arango import ArangoClient
 from arango.database import StandardDatabase
 from networkx.classes import Graph as NXGraph
+from networkx.classes import MultiGraph as NXMultiGraph
 
 from adbnx_adapter import ADBNX_Adapter, ADBNX_Controller
 from adbnx_adapter.typings import Json, NxData, NxId
@@ -100,6 +101,20 @@ def arango_restore(con: Json, path_to_data: str) -> None:
         cwd=f"{PROJECT_DIR}/tests",
         shell=True,
     )
+
+
+def get_drivers_graph() -> NXGraph:
+    nx_g = NXGraph()
+    nx_g.add_edge("P-John", "C-BMW")
+    nx_g.add_edge("P-Mark", "C-Audi")
+    return nx_g
+
+
+def get_likes_graph() -> NXMultiGraph:
+    nx_g = NXGraph()
+    nx_g.add_edge("P-John", "P-Emily", _id="JE", likes=True)
+    nx_g.add_edge("P-Emily", "P-John", _id="EJ", likes=False)
+    return nx_g
 
 
 def get_grid_graph(n: int) -> NXGraph:

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -223,7 +223,7 @@ def test_nx_to_adb(
     assert_arangodb_data(adapter, nx_g, adb_g, keyify_nodes, keyify_edges)
 
 
-def test_nx_to_adb_invalid_collections():
+def test_nx_to_adb_invalid_collections() -> None:
     nx_g_1 = get_drivers_graph()
     e_d_1 = [
         {

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Dict, List, Optional, Set
 
 import pytest
@@ -339,9 +338,7 @@ def test_full_cycle_from_arangodb_with_new_collections() -> None:
             adb_vertex_id: str = str(nx_edge["_id"])
             return adb_vertex_id.split("/")[0] + "_new"
 
-    fraud_adbnx_adapter = ADBNX_Adapter(
-        db, Fraud_ADBNX_Controller(), logging_lvl=logging.DEBUG
-    )
+    fraud_adbnx_adapter = ADBNX_Adapter(db, Fraud_ADBNX_Controller())
 
     new_fraud_adb_g = fraud_adbnx_adapter.networkx_to_arangodb(
         name + "_new",

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -234,7 +234,9 @@ def test_nx_to_adb_invalid_collections() -> None:
     ]
     # Raise ValueError on invalid vertex collection identification
     with pytest.raises(ValueError):
-        adbnx_adapter.networkx_to_arangodb("Drivers", nx_g_1, e_d_1)
+        adbnx_adapter.networkx_to_arangodb(
+            "Drivers", nx_g_1, e_d_1, on_duplicate="replace"
+        )
 
     nx_g_2 = get_likes_graph()
     e_d_2 = [
@@ -251,7 +253,9 @@ def test_nx_to_adb_invalid_collections() -> None:
     ]
     # Raise ValueError on invalid edge collection identification
     with pytest.raises(ValueError):
-        adbnx_adapter.networkx_to_arangodb("Feelings", nx_g_2, e_d_2)
+        adbnx_adapter.networkx_to_arangodb(
+            "Feelings", nx_g_2, e_d_2, on_duplicate="replace"
+        )
 
 
 def test_full_cycle_from_arangodb_with_existing_collections() -> None:

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -12,8 +12,10 @@ from .conftest import (
     adbnx_adapter,
     db,
     football_adbnx_adapter,
+    get_drivers_graph,
     get_football_graph,
     get_grid_graph,
+    get_likes_graph,
     grid_adbnx_adapter,
     imdb_adbnx_adapter,
 )
@@ -219,6 +221,37 @@ def test_nx_to_adb(
         **import_options,
     )
     assert_arangodb_data(adapter, nx_g, adb_g, keyify_nodes, keyify_edges)
+
+
+def test_nx_to_adb_invalid_collections():
+    nx_g_1 = get_drivers_graph()
+    e_d_1 = [
+        {
+            "edge_collection": "drives",
+            "from_vertex_collections": ["Person"],
+            "to_vertex_collections": ["Car"],
+        }
+    ]
+    # Raise ValueError on invalid vertex collection identification
+    with pytest.raises(ValueError):
+        adbnx_adapter.networkx_to_arangodb("Drivers", nx_g_1, e_d_1)
+
+    nx_g_2 = get_likes_graph()
+    e_d_2 = [
+        {
+            "edge_collection": "likes",
+            "from_vertex_collections": ["Person"],
+            "to_vertex_collections": ["Person"],
+        },
+        {
+            "edge_collection": "dislikes",
+            "from_vertex_collections": ["Person"],
+            "to_vertex_collections": ["Person"],
+        },
+    ]
+    # Raise ValueError on invalid edge collection identification
+    with pytest.raises(ValueError):
+        adbnx_adapter.networkx_to_arangodb("Feelings", nx_g_2, e_d_2)
 
 
 def test_full_cycle_from_arangodb_with_existing_collections() -> None:


### PR DESCRIPTION
Note: The scope of this PR has widened, but the branch name has not been updated

### What's new
* raises a `ValueError` if the result of `identify_networkx_node` or `identify_networkx_edge` is not valid
* adds node/edge level logging via a `tqdm` progress meter
* docstring updates
* minor cleanup
* new `__insert_adb_docs` method