### PR TITLE
Update Build Distribution Command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
           python-version: "3.10"
 
       - name: Install release packages
-        run: pip install setuptools wheel twine setuptools-scm[toml]
+        run: pip install build twine
 
       - name: Build distribution
-        run: python setup.py sdist bdist_wheel
+        run: python -m build
 
       - name: Publish to Test PyPi
         env:


### PR DESCRIPTION
Late to the party: https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html