### PR TITLE
new: make edge keyification optional

### DIFF
--- a/adbnx_adapter/abc.py
+++ b/adbnx_adapter/abc.py
@@ -92,7 +92,7 @@ class Abstract_ADBNX_Controller(ABC):
         to_node_id: NxId,
         nx_map: Dict[NxId, str],
         col: str,
-    ) -> str:
+    ) -> str | None:
         raise NotImplementedError  # pragma: no cover
 
     def _prepare_networkx_node(

--- a/adbnx_adapter/abc.py
+++ b/adbnx_adapter/abc.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from abc import ABC
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Union
 
 from arango.graph import Graph as ADBGraph
 from networkx.classes.graph import Graph as NXGraph
@@ -92,7 +92,7 @@ class Abstract_ADBNX_Controller(ABC):
         to_node_id: NxId,
         nx_map: Dict[NxId, str],
         col: str,
-    ) -> str | None:
+    ) -> Union[str, None]:
         raise NotImplementedError  # pragma: no cover
 
     def _prepare_networkx_node(

--- a/adbnx_adapter/adapter.py
+++ b/adbnx_adapter/adapter.py
@@ -639,7 +639,10 @@ class ADBNX_Adapter(Abstract_ADBNX_Adapter):
         key = self.__cntrl._keyify_networkx_node(i, nx_id, nx_node, col)
 
         nx_node["_key"] = key
-        nx_map[nx_id] = f"{col}/{key}"
+
+        _id = f"{col}/{key}"
+        if _id != nx_id:
+            nx_map[nx_id] = _id
 
         self.__cntrl._prepare_networkx_node(nx_node, col)
         adb_docs[col].append(nx_node)
@@ -702,9 +705,10 @@ class ADBNX_Adapter(Abstract_ADBNX_Adapter):
             col,
         )
 
-        nx_edge["_key"] = key
-        nx_edge["_from"] = nx_map[from_node_id]
-        nx_edge["_to"] = nx_map[to_node_id]
+        nx_edge["_from"] = nx_map.get(from_node_id, from_node_id)
+        nx_edge["_to"] = nx_map.get(to_node_id, to_node_id)
+        if key:
+            nx_edge["_key"] = key
 
         self.__cntrl._prepare_networkx_edge(nx_edge, col)
         adb_docs[col].append(nx_edge)

--- a/adbnx_adapter/controller.py
+++ b/adbnx_adapter/controller.py
@@ -4,7 +4,7 @@
 from typing import Any, Dict, List, Tuple
 
 from .abc import Abstract_ADBNX_Controller
-from .typings import Json, NxData, NxId
+from .typings import Json, NxData, NxId, Union
 
 
 class ADBNX_Controller(Abstract_ADBNX_Controller):
@@ -140,7 +140,7 @@ class ADBNX_Controller(Abstract_ADBNX_Controller):
         to_node_id: NxId,
         nx_map: Dict[NxId, str],
         col: str,
-    ) -> str | None:
+    ) -> Union[str, None]:
         """Given a NetworkX edge, its collection, and its pair of nodes, derive
         its ArangoDB key. If None is returned, an auto-generated key will be used.
 

--- a/adbnx_adapter/controller.py
+++ b/adbnx_adapter/controller.py
@@ -140,9 +140,9 @@ class ADBNX_Controller(Abstract_ADBNX_Controller):
         to_node_id: NxId,
         nx_map: Dict[NxId, str],
         col: str,
-    ) -> str:
+    ) -> str | None:
         """Given a NetworkX edge, its collection, and its pair of nodes, derive
-        its ArangoDB key.
+        its ArangoDB key. If None is returned, an auto-generated key will be used.
 
         NOTE #1: You must override this function if you want to create custom ArangoDB
         _key values for your NetworkX edges.
@@ -169,8 +169,8 @@ class ADBNX_Controller(Abstract_ADBNX_Controller):
             i.e, nx_map[from_node_id] will give you the ArangoDB _from value,
             and nx_map[to_node_id] will give you the ArangoDB _to value.
         :type nx_map: Dict[NxId, str]
-        :return: A valid ArangoDB _key value.
-        :rtype: str
+        :return: A valid ArangoDB _key value, or None if you want an auto-generated key.
+        :rtype: str | None
         """
         return str(i)
 


### PR DESCRIPTION
1. Allow edges to be inserted without a `_key` field for auto-generated keys
2. Only update the `nx_map` if the derived Node ID is different from the original Node ID 